### PR TITLE
fixed console error, add key to parent classes after map use

### DIFF
--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -110,7 +110,7 @@ const SinglePokemonPage: React.FC = () => {
                     <div className='row'>
                       {pokemon.prev_evolution?.map((pe, i) => {
                         return (
-                          <div className='col'>
+                          <div className='col'key={i}>
                             <h5 className='text-secondary'>
                               Previous Evolution
                             </h5>
@@ -125,7 +125,7 @@ const SinglePokemonPage: React.FC = () => {
                       })}
                       {pokemon.next_evolution?.map((ne, i) => {
                         return (
-                          <div className='col'>
+                          <div className='col'key={i}>
                             <h5 className='text-secondary'>Next Evolution</h5>
                             <div>
                               <Link to={`/pokemon/${ne.name.toLowerCase()}`}>


### PR DESCRIPTION
## Changes
./src/pages/SinglePokemon.tsx

## Purpose
To Fix console error that renders when navigating to single pokemon page.

## Approach
Keys are required in React to help identify changes to a list. 
fixed with key ={i} 

Fixed Issue # 4